### PR TITLE
ENH: add initial exception API

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,7 +1,15 @@
 ((c-mode . ((mode . c++)
+            (eval . (setq flycheck-gcc-include-path
+                          '("include"
+                            "../"
+                            "../include"
+                            "/usr/include/python3.5m"
+                            "../gtest/googletest/include")))
             (eval . (c-set-offset 'innamespace 0))))
  (c++-mode . ((eval . (setq flycheck-gcc-include-path
                             '("include"
+                              "../"
+                              "../include"
                               "/usr/include/python3.5m"
                               "../gtest/googletest/include")))
               (eval . (c-set-offset 'innamespace 0))

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ scratch.cc
 *.d
 
 gtest/*
+
+# etags
+TAGS

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: cpp
-
-sudo: required
+dist: trusty
+sudo: false
 
 matrix:
   include:
-    - compiler: gcc
+    - compiler: gcc-5
       os: linux
       addons:
         apt:
@@ -16,7 +16,7 @@ matrix:
             - gcc-5
             - g++-5
       env: GCC=5 PYTHON=python3.4
-    - compiler: gcc
+    - compiler: gcc-5
       os: linux
       addons:
         apt:
@@ -28,7 +28,7 @@ matrix:
             - gcc-5
             - g++-5
       env: GCC=5 PYTHON=python3.5
-    - compiler: gcc
+    - compiler: gcc-6
       os: linux
       addons:
         apt:
@@ -40,7 +40,7 @@ matrix:
             - gcc-6
             - g++-6
       env: GCC=6 PYTHON=python3.4
-    - compiler: gcc
+    - compiler: gcc-6
       os: linux
       addons:
         apt:
@@ -52,50 +52,53 @@ matrix:
             - gcc-6
             - g++-6
       env: GCC=6 PYTHON=python3.5
-    - compiler: clang
+    - compiler: clang-3.9
       os: linux
       addons:
         apt:
           sources:
             - deadsnakes
             - ubuntu-toolchain-r-test
-            - llvm-toolchain-precise-3.8
+            - sourceline: "deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-3.9 main"
+              key_url: "http://apt.llvm.org/llvm-snapshot.gpg.key"
           packages:
+            # we install gcc in the clang builds to get an updated libstd++
+            - gcc-5
+            - g++-5
             - python3.4-dev
-            - clang-3.8
-      env: CLANG=3.8 PYTHON=python3.4
-    - compiler: clang
+            - clang-3.9
+      env: CLANG=3.9 PYTHON=python3.4
+    - compiler: clang-3.9
       os: linux
       addons:
         apt:
           sources:
             - deadsnakes
             - ubuntu-toolchain-r-test
-            - llvm-toolchain-precise-3.8
+            - sourceline: "deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-3.9 main"
+              key_url: "http://apt.llvm.org/llvm-snapshot.gpg.key"
           packages:
+            # we install gcc in the clang builds to get an updated libstd++
+            - gcc-5
+            - g++-5
             - python3.5-dev
-            - clang-3.8
-      env: CLANG=3.8 PYTHON=python3.5
+            - clang-3.9
+      env: CLANG=3.9 PYTHON=python3.5
     - compiler: clang
       os: osx
       osx_image: xcode8.1
-      env: PYTHON_VER=3.4.4
+      env: PYTHON_VER=3.4.4 PYTHON=python3
     - compiler: clang
       os: osx
       osx_image: xcode8.1
-      env: PYTHON_VER=3.5.2
+      env: PYTHON_VER=3.5.2 PYTHON=python3
 
 install:
-  - if [ -n "$GCC" ];then export CXX="g++-$GCC" CC="gcc-$GCC";fi
-  - if [ -n "$CLANG" ];then export CXX="clang++-$CLANG" CC="clang-$CLANG";fi
-  - export PYTHON_URL="https://www.python.org/ftp/python/$PYTHON_VER/python-$PYTHON_VER-macosx10.6.pkg"
-  - if [[ "$TRAVIS_OS_NAME" = "osx" ]];then wget "$PYTHON_URL" && sudo installer -pkg "python-$PYTHON_VER-macosx10.6.pkg" -target /;fi
+  - source etc/ci-install.sh
 
 before_script:
   - ${CXX} --version
-  - python --version
-  - python2 --version
-  - python3 --version
+  - ${PYTHON} --version
 
 script:
   - make -j 8 test

--- a/etc/ci-install.sh
+++ b/etc/ci-install.sh
@@ -1,0 +1,15 @@
+# I hate yaml-as-code so damn much. Just use a bash script
+
+set +e
+
+
+if [ -n "$GCC" ];then
+    export CXX="g++-$GCC" CC="gcc-$GCC"
+elif [ -n "$CLANG" ];then
+    export CXX="clang++-$CLANG" CC="clang-$CLANG"
+fi
+
+if [[ "$TRAVIS_OS_NAME" = "osx" ]];then
+    wget "https://www.python.org/ftp/python/$PYTHON_VER/python-$PYTHON_VER-macosx10.6.pkg"
+    sudo installer -pkg "python-$PYTHON_VER-macosx10.6.pkg" -target /
+fi

--- a/include/libpy/err.h
+++ b/include/libpy/err.h
@@ -18,7 +18,7 @@ class object : public py::object {
 private:
     /**
        Function called to verify that `ob` is an exception and
-       correctly raise a python exception otherwies.
+       correctly raise a python exception otherwise.
     */
     void exception_check();
 public:
@@ -59,7 +59,7 @@ public:
        @return Zero on success, non-zero on failure. This will raise a python
                exception on failure.
     */
-    int traceback(py::object tb) const;
+    int traceback(py::object tb);
 
     /**
        Get the context of the exception, set when an exception is raised
@@ -77,7 +77,7 @@ public:
        @param ctx The new context to set. Use `nullptr` to clear it. This steals
                   a reference to `ctx`.
     */
-    void context(py::object ctx) const;
+    void context(py::object ctx);
 
     /**
        Get the cause of the exception set by a `raise ... from ...`.
@@ -93,7 +93,7 @@ public:
        @param cs The new cause to set. Use `nullptr` to clear it. This steals a
                  reference to `cs`.
     */
-    void cause(py::object cs) const;
+    void cause(py::object cs);
 };
 
 typedef py::type::object<object> exctype;

--- a/include/libpy/err.h
+++ b/include/libpy/err.h
@@ -164,7 +164,7 @@ private:
 protected:
     friend msgbuilder raise(exctype type);
     msgbuilder(exctype type);
-    msgbuilder(msgbuilder &&type);
+    msgbuilder(msgbuilder &&type) noexcept;
 public:
     ~msgbuilder();
 };

--- a/include/libpy/err.h
+++ b/include/libpy/err.h
@@ -1,0 +1,257 @@
+#pragma once
+
+#include <sstream>
+
+#include "libpy/object.h"
+#include "libpy/type.h"
+
+#define LIBPY_HAVE_INTERRUPTED_ERROR (PY_VERSION_HEX >= 0x03500000)
+#define LIBPY_HAVE_MODULE_NOT_FOUND_ERROR (PY_VERSION_HEX >= 0x03600000)
+#define LIBPY_HAVE_RECURSION_ERROR (PY_VERSION_HEX >= 0x03500000)
+
+namespace py {
+namespace err {
+/**
+   A subclass of `py::object` for optional exceptions.
+*/
+class object : public py::object {
+private:
+    /**
+       Function called to verify that `ob` is an exception and
+       correctly raise a python exception otherwies.
+    */
+    void exception_check();
+public:
+    /**
+       Default constructor. This will set `ob` to nullptr.
+    */
+    object();
+
+    /**
+       Constructor from `PyObject*`. If `pob` is not an `exception` then
+       `ob` will be set to `nullptr`.
+    */
+    object(PyObject *pob);
+
+    /**
+       Constructor from `py::object`. If `pob` is not an `exception` then
+       `ob` will be set to `nullptr`.
+    */
+    object(const py::object &pob);
+
+    object(const object &cpfrom);
+    object(object &&mvfrom) noexcept;
+
+    using py::object::operator=;
+
+    /**
+       Get the traceback of the exception.
+
+       @return The traceback associated with this exception if one exists,
+               otherwise the returned object is `nullptr`.
+    */
+    py::tmpref<py::object> traceback() const;
+
+    /**
+       Set the traceback of the exception.
+
+       @param tb The new traceback to set. Use `py::None` to clear it.
+       @return Zero on success, non-zero on failure. This will raise a python
+               exception on failure.
+    */
+    int traceback(py::object tb) const;
+
+    /**
+       Get the context of the exception, set when an exception is raised
+       handling another exception.
+
+       @return The context associated with this exception if one exists,
+               otherwise the returned object is `nullptr`.
+    */
+
+    py::tmpref<py::object> context() const;
+
+    /**
+       Set the context of the exception.
+
+       @param ctx The new context to set. Use `nullptr` to clear it. This steals
+                  a reference to `ctx`.
+    */
+    void context(py::object ctx) const;
+
+    /**
+       Get the cause of the exception set by a `raise ... from ...`.
+
+       @return The cause associated with this exception if one exists,
+               otherwise the returned object is `py::None`.
+    */
+    py::tmpref<py::object> cause() const;
+
+    /**
+       Set the cause of the exception.
+
+       @param cs The new cause to set. Use `nullptr` to clear it. This steals a
+                 reference to `cs`.
+    */
+    void cause(py::object cs) const;
+};
+
+typedef py::type::object<object> exctype;
+
+extern const exctype BaseException;
+extern const exctype Exception;
+extern const exctype ArithmeticError;
+extern const exctype LookupError;
+extern const exctype AssertionError;
+extern const exctype AttributeError;
+extern const exctype BlockingIOError;
+extern const exctype BrokenPipeError;
+extern const exctype ChildProcessError;
+extern const exctype ConnectionError;
+extern const exctype ConnectionAbortedError;
+extern const exctype ConnectionRefusedError;
+extern const exctype ConnectionResetError;
+extern const exctype FileExistsError;
+extern const exctype FileNotFoundError;
+extern const exctype EOFError;
+extern const exctype FloatingPointError;
+extern const exctype ImportError;
+#if LIBPY_HAVE_MODULE_NOT_FOUND_ERROR
+extern const exctype ModuleNotFoundError;
+#endif
+extern const exctype IndexError;
+#if LIBPY_HAVE_INTERRUPTED_ERROR
+extern const exctype InterruptedError;
+#endif
+extern const exctype IsADirectoryError;
+extern const exctype KeyError;
+extern const exctype KeyboardInterrupt;
+extern const exctype MemoryError;
+extern const exctype NameError;
+extern const exctype NotADirectoryError;
+extern const exctype NotImplementedError;
+extern const exctype OSError;
+extern const exctype OverflowError;
+extern const exctype PermissionError;
+extern const exctype ProcessLookupError;
+#if LIBPY_HAVE_RECURSION_ERROR
+extern const exctype RecursionError;
+#endif
+extern const exctype ReferenceError;
+extern const exctype RuntimeError;
+extern const exctype SyntaxError;
+extern const exctype SystemError;
+extern const exctype TimeoutError;
+extern const exctype SystemExit;
+extern const exctype TypeError;
+extern const exctype ValueError;
+extern const exctype ZeroDivisionError;
+#ifdef MS_WINDOWS
+extern const exctype WindowsError;
+#endif
+
+// OSError aliases
+extern const exctype EnvironmentError;
+extern const exctype IOError;
+
+/**
+   Helper class used to raise exceptions with error messages.
+*/
+class msgbuilder : public std::stringstream {
+private:
+    exctype type;
+    bool fire;
+protected:
+    friend msgbuilder raise(exctype type);
+    msgbuilder(exctype type);
+    msgbuilder(msgbuilder &&type);
+public:
+    ~msgbuilder();
+};
+
+/**
+   Get the currently raised exception. This object will be wrapping `nullptr`
+   if there is no active exception.
+
+   @return The currently raised exception if any.
+*/
+inline exctype occurred() {
+    return PyErr_Occurred();
+}
+
+/**
+   Clear the active exception. If there is no active exception, this is a nop.
+*/
+inline void clear() {
+    PyErr_Clear();
+}
+
+/**
+   Raise an exception with a message.
+
+   @param type The type of exception to raise.
+   @return An `ostream` which will accumulate the message to send.
+*/
+msgbuilder raise(exctype type);
+
+/**
+   Raise an exception value.
+*/
+void raise(py::err::object err);
+
+/**
+   Raise `py::err::MemoryError` and return `nullptr`.
+
+   @return Always `nullptr` so users may write: `return no_memory()`.
+*/
+inline std::nullptr_t no_memory() {
+    PyErr_NoMemory();
+    return nullptr;
+}
+
+/**
+   Raise `type` with the errno integer and message from `strerror()`.
+
+   @param type The type of exception to raise.
+
+   @return Always `nullptr` so users may write: `return set_from_errno(...)`.
+*/
+inline std::nullptr_t set_from_errno(exctype type) {
+    PyErr_SetFromErrno(type);
+    return nullptr;
+}
+
+/**
+   Raise `type` with the errno integer and message from `strerror()`.
+
+   @param type The type of exception to raise.
+   @param filename If not null, `filename` is passed as the third argument to
+                   the constructor of `type` after `errno` and `strerror()`.
+
+   @return Always `nullptr` so users may write: `return set_from_errno(...)`.
+*/
+inline std::nullptr_t set_from_errno(exctype type, py::object filename) {
+    PyErr_SetFromErrnoWithFilenameObject(type, filename);
+    return nullptr;
+}
+
+
+/**
+   Raise `type` with the errno integer and message from `strerror()`.
+
+   @param type The type of exception to raise.
+   @param filename1 Passed as the third argument to the constructor of `type`
+                    after `errno` and `strerror()`.
+   @param filename2 Passed as the fourth argument to the constructor of `type`
+                    after `errno`, `strerror()`, and `filename1`.
+
+   @return Always `nullptr` so users may write: `return set_from_errno(...)`.
+*/
+inline std::nullptr_t set_from_errno(exctype type,
+                                     py::object filename1,
+                                     py::object filename2) {
+    PyErr_SetFromErrnoWithFilenameObjects(type, filename1, filename2);
+    return nullptr;
+}
+}
+}

--- a/include/libpy/libpy.h
+++ b/include/libpy/libpy.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "libpy/err.h"
 #include "libpy/object.h"
 #include "libpy/tuple.h"
 #include "libpy/type.h"

--- a/include/libpy/object.h
+++ b/include/libpy/object.h
@@ -5,7 +5,7 @@
 
 #include "libpy/utils.h"
 
-#define HAVE_MATMUL (PY_VERSION_HEX >= 0x03500000)
+#define LIBPY_HAVE_MATMUL (PY_VERSION_HEX >= 0x03500000)
 
 /**
    A namespace to hold all of the C++ adapted CPython API types, functions, and
@@ -640,7 +640,7 @@ public:
         return ob_binary_func<PyNumber_Multiply>(other);
     }
 
-#if CPP_HAVE_MATMUL
+#if LIBPY_HAVE_MATMUL
     template<typename T>
     tmpref<object> matmul(const T &other) const {
         return ob_binary_func<PyNumber_MatrixMultiple>(other);

--- a/include/libpy/type.h
+++ b/include/libpy/type.h
@@ -18,6 +18,8 @@ public:
 
     object(PyObject *pob) : py::object(pob) {}
 
+    object(PyTypeObject *pob) : py::object(reinterpret_cast<PyObject*>(pob)) {}
+
     object(const object &cpfrom) : py::object(cpfrom.ob) {}
 
     object(object &&mvfrom) noexcept : py::object(mvfrom.ob) {

--- a/src/err.cc
+++ b/src/err.cc
@@ -138,7 +138,7 @@ void py::err::object::cause(py::object cs) {
 
 py::err::msgbuilder::msgbuilder(py::err::exctype type) :
     type(type), fire(true) {}
-py::err::msgbuilder::msgbuilder(msgbuilder &&mvfrom) :
+py::err::msgbuilder::msgbuilder(msgbuilder &&mvfrom) noexcept :
     std::stringstream(std::forward<msgbuilder>(mvfrom)), type(mvfrom.type) {
     mvfrom.fire = false;
 }

--- a/src/err.cc
+++ b/src/err.cc
@@ -82,8 +82,8 @@ void py::err::object::exception_check() {
     if (ob && !PyExceptionClass_Check(Py_TYPE(ob))) {
         ob = nullptr;
         if (!PyErr_Occurred()) {
-            PyErr_Format(TypeError,
-                         "cannot make py::err::object from non exception");
+            PyErr_SetString(TypeError,
+                            "cannot make py::err::object from non exception");
         }
     }
 }
@@ -96,7 +96,7 @@ py::tmpref<py::object> py::err::object::traceback() const {
     return PyException_GetTraceback(ob);
 }
 
-int py::err::object::traceback(py::object tb) const {
+int py::err::object::traceback(py::object tb) {
     if (!is_nonnull()) {
         pyutils::failed_null_check();
         return -1;
@@ -112,13 +112,12 @@ py::tmpref<py::object> py::err::object::context() const {
     return PyException_GetContext(ob);
 }
 
-void py::err::object::context(py::object tb) const {
+void py::err::object::context(py::object tb) {
     if (!is_nonnull()) {
         pyutils::failed_null_check();
+        return;
     }
-    else {
-        PyException_SetContext(ob, tb);
-    }
+    PyException_SetContext(ob, tb);
 }
 
 py::tmpref<py::object> py::err::object::cause() const {
@@ -129,13 +128,12 @@ py::tmpref<py::object> py::err::object::cause() const {
     return PyException_GetCause(ob);
 }
 
-void py::err::object::cause(py::object cs) const {
+void py::err::object::cause(py::object cs) {
     if (!is_nonnull()) {
         pyutils::failed_null_check();
+        return;
     }
-    else {
-        PyException_SetCause(ob, cs);
-    }
+    PyException_SetCause(ob, cs);
 }
 
 py::err::msgbuilder::msgbuilder(py::err::exctype type) :

--- a/src/err.cc
+++ b/src/err.cc
@@ -1,0 +1,159 @@
+#include "libpy/err.h"
+
+namespace {
+namespace e = py::err;
+}
+
+const e::exctype e::BaseException(PyExc_BaseException);
+const e::exctype e::Exception(PyExc_Exception);
+const e::exctype e::ArithmeticError(PyExc_ArithmeticError);
+const e::exctype e::LookupError(PyExc_LookupError);
+const e::exctype e::AssertionError(PyExc_AssertionError);
+const e::exctype e::AttributeError(PyExc_AttributeError);
+const e::exctype e::BlockingIOError(PyExc_BlockingIOError);
+const e::exctype e::BrokenPipeError(PyExc_BrokenPipeError);
+const e::exctype e::ChildProcessError(PyExc_ChildProcessError);
+const e::exctype e::ConnectionError(PyExc_ConnectionError);
+const e::exctype e::ConnectionAbortedError(PyExc_ConnectionAbortedError);
+const e::exctype e::ConnectionRefusedError(PyExc_ConnectionRefusedError);
+const e::exctype e::ConnectionResetError(PyExc_ConnectionResetError);
+const e::exctype e::FileExistsError(PyExc_FileExistsError);
+const e::exctype e::FileNotFoundError(PyExc_FileNotFoundError);
+const e::exctype e::EOFError(PyExc_EOFError);
+const e::exctype e::FloatingPointError(PyExc_FloatingPointError);
+const e::exctype e::ImportError(PyExc_ImportError);
+#if LIBPY_HAVE_MODULE_NOT_FOUND_ERROR
+const e::exctype e::ModuleNotFoundError(PyExc_ModuleNotFoundError);
+#endif
+const e::exctype e::IndexError(PyExc_IndexError);
+#if LIBPY_HAVE_INTERRUPTED_ERROR
+const e::exctype e::InterruptedError(PyExc_InterruptedError);
+#endif
+const e::exctype e::IsADirectoryError(PyExc_IsADirectoryError);
+const e::exctype e::KeyError(PyExc_KeyError);
+const e::exctype e::KeyboardInterrupt(PyExc_KeyboardInterrupt);
+const e::exctype e::MemoryError(PyExc_MemoryError);
+const e::exctype e::NameError(PyExc_NameError);
+const e::exctype e::NotADirectoryError(PyExc_NotADirectoryError);
+const e::exctype e::NotImplementedError(PyExc_NotImplementedError);
+const e::exctype e::OSError(PyExc_OSError);
+const e::exctype e::OverflowError(PyExc_OverflowError);
+const e::exctype e::PermissionError(PyExc_PermissionError);
+const e::exctype e::ProcessLookupError(PyExc_ProcessLookupError);
+#if LIBPY_HAVE_RECURSION_ERROR
+const e::exctype e::RecursionError(PyExc_RecursionError);
+#endif
+const e::exctype e::ReferenceError(PyExc_ReferenceError);
+const e::exctype e::RuntimeError(PyExc_RuntimeError);
+const e::exctype e::SyntaxError(PyExc_SyntaxError);
+const e::exctype e::SystemError(PyExc_SystemError);
+const e::exctype e::TimeoutError(PyExc_TimeoutError);
+const e::exctype e::SystemExit(PyExc_SystemExit);
+const e::exctype e::TypeError(PyExc_TypeError);
+const e::exctype e::ValueError(PyExc_ValueError);
+const e::exctype e::ZeroDivisionError(PyExc_ZeroDivisionError);
+#if MS_WINDOWS
+const e::exctype e::WindowsError(PyExc_WindowsError);
+#endif
+
+// OSError aliases
+const py::err::exctype EnvironmentError(PyExc_EnvironmentError);
+const py::err::exctype IOError(PyExc_IOError);
+
+py::err::object::object() : py::object() {}
+
+py::err::object::object(PyObject *pob) : py::object(pob) {
+    exception_check();
+}
+
+py::err::object::object(const py::object &pob) : py::object(pob) {
+    exception_check();
+}
+
+py::err::object::object(const py::err::object &cpfrom) :
+    py::object(cpfrom.ob) {}
+
+py::err::object::object(py::err::object &&mvfrom) noexcept :
+    py::object(mvfrom.ob) {
+    mvfrom.ob = nullptr;
+}
+
+void py::err::object::exception_check() {
+    if (ob && !PyExceptionClass_Check(Py_TYPE(ob))) {
+        ob = nullptr;
+        if (!PyErr_Occurred()) {
+            PyErr_Format(TypeError,
+                         "cannot make py::err::object from non exception");
+        }
+    }
+}
+
+py::tmpref<py::object> py::err::object::traceback() const {
+    if (!is_nonnull()) {
+        pyutils::failed_null_check();
+        return nullptr;
+    }
+    return PyException_GetTraceback(ob);
+}
+
+int py::err::object::traceback(py::object tb) const {
+    if (!is_nonnull()) {
+        pyutils::failed_null_check();
+        return -1;
+    }
+    return PyException_SetTraceback(ob, tb);
+}
+
+py::tmpref<py::object> py::err::object::context() const {
+    if (!is_nonnull()) {
+        pyutils::failed_null_check();
+        return nullptr;
+    }
+    return PyException_GetContext(ob);
+}
+
+void py::err::object::context(py::object tb) const {
+    if (!is_nonnull()) {
+        pyutils::failed_null_check();
+    }
+    else {
+        PyException_SetContext(ob, tb);
+    }
+}
+
+py::tmpref<py::object> py::err::object::cause() const {
+    if (!is_nonnull()) {
+        pyutils::failed_null_check();
+        return nullptr;
+    }
+    return PyException_GetCause(ob);
+}
+
+void py::err::object::cause(py::object cs) const {
+    if (!is_nonnull()) {
+        pyutils::failed_null_check();
+    }
+    else {
+        PyException_SetCause(ob, cs);
+    }
+}
+
+py::err::msgbuilder::msgbuilder(py::err::exctype type) :
+    type(type), fire(true) {}
+py::err::msgbuilder::msgbuilder(msgbuilder &&mvfrom) :
+    std::stringstream(std::forward<msgbuilder>(mvfrom)), type(mvfrom.type) {
+    mvfrom.fire = false;
+}
+py::err::msgbuilder::~msgbuilder() {
+    if (fire) {
+        PyErr_SetString(type, str().c_str());
+    }
+}
+
+py::err::msgbuilder py::err::raise(py::err::exctype type) {
+    return msgbuilder(type);
+}
+
+void py::err::raise(py::err::object err) {
+    PyErr_SetObject(err.type(), err);
+}

--- a/src/list.cc
+++ b/src/list.cc
@@ -1,10 +1,11 @@
 #include "libpy/list.h"
 #include "libpy/utils.h"
 
+namespace {
 namespace l = py::list;
+}
 
-const py::type::object<l::object>
-l::type(reinterpret_cast<PyObject*>(&PyList_Type));
+const py::type::object<l::object> l::type(&PyList_Type);
 
 l::object::object() : py::object() {}
 

--- a/src/long.cc
+++ b/src/long.cc
@@ -13,8 +13,7 @@ const py::long_::object &py::operator""_p(unsigned long long l) {
     return ob;
 }
 
-const py::type::object<py::long_::object>
-py::long_::type(reinterpret_cast<PyObject*>(&PyList_Type));
+const py::type::object<py::long_::object> py::long_::type(&PyList_Type);
 
 py::long_::object::object() : py::object(nullptr) {}
 

--- a/src/tuple.cc
+++ b/src/tuple.cc
@@ -1,10 +1,11 @@
 #include "libpy/tuple.h"
 #include "libpy/utils.h"
 
+namespace {
 namespace t = py::tuple;
+}
 
-const py::type::object<t::object>
-t::type(reinterpret_cast<PyObject*>(&PyTuple_Type));
+const py::type::object<t::object> t::type(&PyTuple_Type);
 
 t::object::object() : py::object() {}
 

--- a/test/test_err.cc
+++ b/test/test_err.cc
@@ -1,0 +1,23 @@
+#include <gtest/gtest.h>
+#include <Python.h>
+
+#include "libpy/libpy.h"
+#include "utils.h"
+
+using py::operator""_p;
+
+TEST(Err, raise_with_message) {
+    py::err::raise(py::err::TypeError) << "ayy lmao: " << 1_p;
+    EXPECT_PYTHON_ERR_MSG(py::err::TypeError, "ayy lmao: 1"_p);
+}
+
+TEST(Err, raise_value) {
+    py::err::raise(py::err::TypeError("ayy lmao"_p));
+    EXPECT_PYTHON_ERR_MSG(py::err::TypeError, "ayy lmao"_p);
+}
+
+TEST(Err, occurred) {
+    PyErr_SetString(py::err::TypeError, "ayy lmao");
+    EXPECT_IS(py::err::occurred(), py::err::TypeError);
+    py::err::clear();
+}

--- a/test/test_long.cc
+++ b/test/test_long.cc
@@ -13,7 +13,7 @@ TEST(Long, default) {
     py::long_::object n;
 
     EXPECT_IS(n, nullptr);
-    EXPECT_FALSE(PyErr_Occurred());
+    EXPECT_EQ(PyErr_Occurred(), nullptr) << py::err::occurred();
 }
 
 #define FROM_NUMERIC_TEST_BASE(type) {                          \

--- a/test/test_readme.cc
+++ b/test/test_readme.cc
@@ -10,6 +10,6 @@ py::tmpref<py::object> f() {
 
 TEST(ReadMe, example) {
     auto ob = f();
+    EXPECT_TRUE((ob == 6.5_p).istrue());
     EXPECT_EQ(ob.refcnt(), 1);
-    EXPECT_TRUE((f() == 6.5_p).istrue());
 }

--- a/test/utils.h
+++ b/test/utils.h
@@ -3,6 +3,8 @@
 #include "gtest/gtest.h"
 #include <Python.h>
 
+#include "libpy/libpy.h"
+
 /**
    Expectation that two object are the same object in memory.
 */
@@ -30,17 +32,36 @@
 
 /**
    Expectation that a particular kind of python exception was raised.
-
-   If the correct type was raised the exception is cleared.
+   Any exceptions are cleared after this.
 
    @param type The python exception class to check against.
 */
 #define EXPECT_PYTHON_ERR(type) {                       \
         bool matches = PyErr_ExceptionMatches(type);    \
         EXPECT_TRUE(matches);                           \
-        if (matches) {                                  \
-            PyErr_Clear();                              \
-        }                                               \
+        PyErr_Clear();                                  \
+    }(void) 0
+
+
+/**
+   Expectation that a particular kind of python exception was raised and that
+   the message matches some text.
+   Any exceptions are cleared after this.
+
+   @param type The python exception class to check against.
+   @param msg The message text to check for.
+*/
+#define EXPECT_PYTHON_ERR_MSG(type, msg) {                              \
+        bool matches = PyErr_ExceptionMatches(type);                    \
+        EXPECT_TRUE(matches);                                           \
+        PyObject *type_;                                                \
+        PyObject *value;                                                \
+        PyObject *tb;                                                   \
+        PyErr_Fetch(&type_, &value, &tb);                               \
+        EXPECT_TRUE((py::object(value).str() == msg).istrue());         \
+        Py_DECREF(type_);                                               \
+        Py_DECREF(value);                                               \
+        Py_XDECREF(tb);                                                 \
     }(void) 0
 
 /**

--- a/test/utils.h
+++ b/test/utils.h
@@ -21,13 +21,13 @@
    When this fails the exception is printed with PyErr_Print and then it is
    cleared.
 */
-#define EXPECT_NO_PYTHON_ERR() {                \
-        PyObject *occured = PyErr_Occurred();   \
-        EXPECT_FALSE(occured);                  \
-        if (occured) {                          \
-            PyErr_Print();                      \
-            PyErr_Clear();                      \
-        }                                       \
+#define EXPECT_NO_PYTHON_ERR() {                                        \
+        py::object occurred(PyErr_Occurred());                          \
+        EXPECT_FALSE(occurred) << "actually raised: " << occurred;      \
+        if (occured) {                                                  \
+            PyErr_Print();                                              \
+            PyErr_Clear();                                              \
+        }                                                               \
     }(void) 0
 
 /**

--- a/test/utils.h
+++ b/test/utils.h
@@ -22,9 +22,9 @@
    cleared.
 */
 #define EXPECT_NO_PYTHON_ERR() {                                        \
-        py::object occurred(PyErr_Occurred());                          \
+        py::object occurred{PyErr_Occurred()};                          \
         EXPECT_FALSE(occurred) << "actually raised: " << occurred;      \
-        if (occured) {                                                  \
+        if (occurred) {                                                 \
             PyErr_Print();                                              \
             PyErr_Clear();                                              \
         }                                                               \


### PR DESCRIPTION
The main interesting feature is raising with a formatted message. To do this, I am proposing the syntax:

``` c++
raise(type) << ostream_compatible_things << ... ;
```

I wanted something to replace `PyErr_Format` without losing type safety. `py::object` is already ostream compatible. To get things like `%R` you can do:

``` c++
raise(type) << object.repr();
```

which is easy enough.
