### PR TITLE
Osx travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -78,14 +78,18 @@ matrix:
       env: CLANG=3.8 PYTHON=python3.5
     - compiler: clang
       os: osx
+      osx_image: xcode8.1
 
 install:
   - if [ -n "$GCC" ];then export CXX="g++-$GCC" CC="gcc-$GCC";fi
   - if [ -n "$CLANG" ];then export CXX="clang++-$CLANG" CC="clang-$CLANG";fi
-  - if [[ "$TRAVIS_OS_NAME" = "osx" ]];then brew install python3;fi
+  - if [[ "$TRAVIS_OS_NAME" = "osx" ]];then wget https://www.python.org/ftp/python/3.5.2/python-3.5.2-macosx10.6.pkg && sudo installer -pkg python-3.5.2-macosx10.6.pkg -target /;fi
 
 before_script:
   - ${CXX} --version
+  - python --version
+  - python2 --version
+  - python3 --version
 
 script:
   - make -j 8 test

--- a/.travis.yml
+++ b/.travis.yml
@@ -79,11 +79,17 @@ matrix:
     - compiler: clang
       os: osx
       osx_image: xcode8.1
+      env: PYTHON_VER=3.4.4
+    - compiler: clang
+      os: osx
+      osx_image: xcode8.1
+      env: PYTHON_VER=3.5.2
 
 install:
   - if [ -n "$GCC" ];then export CXX="g++-$GCC" CC="gcc-$GCC";fi
   - if [ -n "$CLANG" ];then export CXX="clang++-$CLANG" CC="clang-$CLANG";fi
-  - if [[ "$TRAVIS_OS_NAME" = "osx" ]];then wget https://www.python.org/ftp/python/3.5.2/python-3.5.2-macosx10.6.pkg && sudo installer -pkg python-3.5.2-macosx10.6.pkg -target /;fi
+  - export PYTHON_URL="https://www.python.org/ftp/python/$PYTHON_VER/python-$PYTHON_VER-macosx10.6.pkg"
+  - if [[ "$TRAVIS_OS_NAME" = "osx" ]];then wget "$PYTHON_URL" && sudo installer -pkg "python-$PYTHON_VER-macosx10.6.pkg" -target /;fi
 
 before_script:
   - ${CXX} --version

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ MINOR_VERSION := 0
 MICRO_VERSION := 0
 # strict-prototypes is for C/ObjC only:
 CXXFLAGS := -std=gnu++14 -Wall -Wextra -O3 -g -fno-strict-aliasing \
-	$(shell $(PYTHON)-config --cflags | sed s/"-Wstrict-prototypes"//g)
+	$(shell $(PYTHON)-config --cflags | sed s/"-Wstrict-prototypes"//g) -Wno-missing-braces
 LDFLAGS := $(shell $(PYTHON)-config --ldflags)
 SOURCES :=$(wildcard src/*.cc)
 OBJECTS :=$(SOURCES:.cc=.o)


### PR DESCRIPTION
1. Xcode and python versions are now pinned in the travis OSX build.
1. On OSX, build with both pythons 3.4 and 3.5.
1. With the newer Xcode, the build fails without https://github.com/llllllllll/libpy/pull/4/commits/3043782088b6825873f98396cc07ac655a732ffb 👍 .
1. Per http://stackoverflow.com/a/13905432 and previous discussions with @llllllllll, suppress the missing braces warnings that clang generates.